### PR TITLE
chore: add gcc and make to system dependencies in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,7 +150,7 @@ jobs:
       - name: Install system dependencies
         run: |
           dnf install -y \
-            git curl tar \
+            git curl tar gcc make \
             webkit2gtk4.1-devel \
             openssl-devel \
             gtk3-devel \


### PR DESCRIPTION
This pull request makes a small update to the system dependencies installed in the release workflow. The change adds `gcc` and `make` to the list of packages, ensuring that build tools are available during the workflow execution.