### PR TITLE
fix(storage): set explicit 0o644 after atomic rename to prevent EACCE…

### DIFF
--- a/crates/storage/src/atomic.rs
+++ b/crates/storage/src/atomic.rs
@@ -22,6 +22,15 @@ pub fn atomic_write_bytes(path: &Path, data: &[u8]) -> StorageResult<()> {
 
     fs::rename(&tmp_path, path)?;
 
+    // Explicit chmod after rename so permissions are not subject to the process umask.
+    // Without this, files opened from a downloaded workspace can get e.g. 0o600 and
+    // cause EACCES (OS error 13) when the app tries to rewrite them on next open.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = fs::set_permissions(path, fs::Permissions::from_mode(0o644));
+    }
+
     if let Some(parent) = path.parent() {
         if let Ok(dir) = fs::File::open(parent) {
             let _ = dir.sync_all();

--- a/src-tauri/src/commands/sync.rs
+++ b/src-tauri/src/commands/sync.rs
@@ -515,10 +515,8 @@ pub async fn download_workspace(
                 use std::os::unix::fs::PermissionsExt;
                 let mut ancestor = parent;
                 while ancestor != dest {
-                    let _ = std::fs::set_permissions(
-                        ancestor,
-                        std::fs::Permissions::from_mode(0o755),
-                    );
+                    let _ =
+                        std::fs::set_permissions(ancestor, std::fs::Permissions::from_mode(0o755));
                     match ancestor.parent() {
                         Some(p) => ancestor = p,
                         None => break,

--- a/src-tauri/src/commands/sync.rs
+++ b/src-tauri/src/commands/sync.rs
@@ -507,11 +507,23 @@ pub async fn download_workspace(
                 ));
                 continue;
             }
-            // Ensure subdirectories are also writable on Unix.
+            // Set 0o755 on ALL intermediate directories between dest and this file's parent,
+            // not just the direct parent. create_dir_all may create several levels that
+            // inherit the process umask instead of getting explicit permissions.
             #[cfg(unix)]
             {
                 use std::os::unix::fs::PermissionsExt;
-                let _ = std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o755));
+                let mut ancestor = parent;
+                while ancestor != dest {
+                    let _ = std::fs::set_permissions(
+                        ancestor,
+                        std::fs::Permissions::from_mode(0o755),
+                    );
+                    match ancestor.parent() {
+                        Some(p) => ancestor = p,
+                        None => break,
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
…S on open

atomic_write_bytes relied on the process umask for final file permissions. When a restrictive umask (e.g. 0o027) was active, renamed files could end up with 0o640 or 0o600, causing OS error 13 (EACCES) the next time the app tried to rewrite them (e.g. save_workspace on open_workspace).

Also fix download_workspace to set 0o755 on ALL intermediate directories created by create_dir_all, not just the direct parent of each file.