### PR TITLE
Enhance error reporting and embed OAuth credentials in build

### DIFF
--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -11,6 +11,7 @@ serde_json = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 thiserror = { workspace = true }
+log = "0.4"
 unicode-normalization = "0.1"
 
 # criptografia

--- a/crates/storage/src/atomic.rs
+++ b/crates/storage/src/atomic.rs
@@ -16,11 +16,24 @@ pub fn atomic_write_bytes(path: &Path, data: &[u8]) -> StorageResult<()> {
         fs::create_dir_all(parent)?;
     }
 
-    let mut file = fs::File::create(&tmp_path)?;
-    file.write_all(data)?;
+    let mut file = fs::File::create(&tmp_path).map_err(|e| {
+        std::io::Error::new(e.kind(), format!("create '{}': {e}", tmp_path.display()))
+    })?;
+    file.write_all(data).map_err(|e| {
+        std::io::Error::new(e.kind(), format!("write '{}': {e}", tmp_path.display()))
+    })?;
     file.sync_all()?;
 
-    fs::rename(&tmp_path, path)?;
+    fs::rename(&tmp_path, path).map_err(|e| {
+        std::io::Error::new(
+            e.kind(),
+            format!(
+                "rename '{}' -> '{}': {e}",
+                tmp_path.display(),
+                path.display()
+            ),
+        )
+    })?;
 
     // Explicit chmod after rename so permissions are not subject to the process umask.
     // Without this, files opened from a downloaded workspace can get e.g. 0o600 and

--- a/crates/storage/src/engine.rs
+++ b/crates/storage/src/engine.rs
@@ -104,13 +104,54 @@ impl FsStorageEngine {
         // under a restrictive umask) do not cause EACCES on the subsequent operations.
         Self::repair_workspace_permissions(root_path);
 
-        lock::acquire_lock(root_path)?;
-        let mut workspace = Self::load_workspace(root_path)?;
+        log::debug!("[open_workspace] acquire_lock at '{}'", root_path.display());
+        lock::acquire_lock(root_path).map_err(|e| {
+            log::error!(
+                "[open_workspace] acquire_lock FAILED at '{}': {e}",
+                root_path.display()
+            );
+            e
+        })?;
+
+        log::debug!(
+            "[open_workspace] load_workspace at '{}'",
+            root_path.display()
+        );
+        let mut workspace = Self::load_workspace(root_path).map_err(|e| {
+            log::error!(
+                "[open_workspace] load_workspace FAILED at '{}': {e}",
+                root_path.join(WORKSPACE_FILE).display()
+            );
+            e
+        })?;
+
         workspace.updated_at = Utc::now();
-        Self::save_workspace(&workspace)?;
 
-        Self::cleanup_expired_trash(root_path)?;
+        log::debug!(
+            "[open_workspace] save_workspace at '{}'",
+            root_path.display()
+        );
+        Self::save_workspace(&workspace).map_err(|e| {
+            log::error!(
+                "[open_workspace] save_workspace FAILED at '{}': {e}",
+                root_path.join(WORKSPACE_FILE).display()
+            );
+            e
+        })?;
 
+        log::debug!(
+            "[open_workspace] cleanup_expired_trash at '{}'",
+            root_path.display()
+        );
+        Self::cleanup_expired_trash(root_path).map_err(|e| {
+            log::error!(
+                "[open_workspace] cleanup_expired_trash FAILED at '{}': {e}",
+                root_path.display()
+            );
+            e
+        })?;
+
+        log::debug!("[open_workspace] success at '{}'", root_path.display());
         Ok(workspace)
     }
 

--- a/crates/storage/src/lock.rs
+++ b/crates/storage/src/lock.rs
@@ -24,13 +24,17 @@ pub fn acquire_lock(workspace_root: &Path) -> StorageResult<()> {
     let path = lock_path(workspace_root);
 
     if path.exists() {
-        let content = fs::read_to_string(&path)?;
+        let content = fs::read_to_string(&path).map_err(|e| {
+            std::io::Error::new(e.kind(), format!("read_lock '{}': {e}", path.display()))
+        })?;
         if let Ok(lock) = serde_json::from_str::<LockFile>(&content) {
             if is_process_alive(lock.pid) {
                 return Err(StorageError::WorkspaceLocked { pid: lock.pid });
             }
         }
-        fs::remove_file(&path)?;
+        fs::remove_file(&path).map_err(|e| {
+            std::io::Error::new(e.kind(), format!("remove_lock '{}': {e}", path.display()))
+        })?;
     }
 
     let lock = LockFile {

--- a/crates/sync/build.rs
+++ b/crates/sync/build.rs
@@ -1,0 +1,31 @@
+use std::fs;
+use std::path::Path;
+
+fn main() {
+    // Load .env.local from the workspace root so that option_env!("GOOGLE_CLIENT_ID")
+    // etc. resolve at compile time in this crate's provider modules.
+    let env_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join(".env.local");
+
+    if let Ok(content) = fs::read_to_string(&env_path) {
+        for line in content.lines() {
+            let line = line.trim();
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+            if let Some((key, value)) = line.split_once('=') {
+                let key = key.trim();
+                let value = value.trim().trim_matches('"').trim_matches('\'');
+                if !key.is_empty() {
+                    println!("cargo:rustc-env={key}={value}");
+                }
+            }
+        }
+    }
+
+    println!("cargo:rerun-if-changed={}", env_path.display());
+}

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,36 @@
+use std::fs;
+use std::path::Path;
+
 fn main() {
+    // Load .env.local from the workspace root (one level above src-tauri/) so that
+    // option_env!("GOOGLE_CLIENT_ID") etc. are resolved at compile time.
+    // This allows `cargo tauri build` to embed credentials without requiring the
+    // environment to be set externally.
+    let env_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join(".env.local");
+
+    if let Ok(content) = fs::read_to_string(&env_path) {
+        for line in content.lines() {
+            let line = line.trim();
+            // Skip comments and empty lines.
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+            if let Some((key, value)) = line.split_once('=') {
+                let key = key.trim();
+                // Strip surrounding quotes from the value if present.
+                let value = value.trim().trim_matches('"').trim_matches('\'');
+                if !key.is_empty() {
+                    println!("cargo:rustc-env={key}={value}");
+                }
+            }
+        }
+    }
+
+    // Re-run this build script whenever .env.local changes.
+    println!("cargo:rerun-if-changed={}", env_path.display());
+
     tauri_build::build()
 }

--- a/src-tauri/src/commands/sync.rs
+++ b/src-tauri/src/commands/sync.rs
@@ -462,6 +462,24 @@ pub async fn download_workspace(
     let provider_type = parse_provider_type(&provider_name)?;
     let provider = providers::create_provider(provider_type);
 
+    // Before downloading, check whether this workspace already exists locally by
+    // comparing names against recently opened workspaces. If found, skip the
+    // download and return the existing path to avoid duplicates.
+    if let Ok(app_state) = opennote_storage::engine::FsStorageEngine::load_app_state() {
+        if let Some(existing) = app_state
+            .recent_workspaces
+            .iter()
+            .find(|rw| rw.name == workspace_name)
+        {
+            if existing.path.join("workspace.json").exists() {
+                return Ok(DownloadResult {
+                    count: 0,
+                    local_path: existing.path.to_string_lossy().into_owned(),
+                });
+            }
+        }
+    }
+
     let remote_root = format!("OpenNote/{}", workspace_name);
     let remote_files = provider
         .list_all_remote_files(&token, &remote_root)

--- a/src/components/sync/CloudImportModal.tsx
+++ b/src/components/sync/CloudImportModal.tsx
@@ -29,6 +29,7 @@ interface WorkspaceState {
   status: WorkspaceStatus;
   count?: number;
   localPath?: string;
+  alreadyExists?: boolean;
   error?: string;
   openError?: string;
 }
@@ -74,6 +75,7 @@ export function CloudImportModal({
         status: "done",
         count: result.count,
         localPath: result.local_path,
+        alreadyExists: result.count === 0 && !!result.local_path,
       });
     } catch (e) {
       setWsState(ws.name, { status: "error", error: String(e) });
@@ -235,7 +237,9 @@ export function CloudImportModal({
                   <div className="flex flex-col items-end gap-1">
                     <span className="flex items-center gap-1 text-xs font-medium text-green-500">
                       <CheckCircle size={13} />
-                      {t("sync.import_done", { count: wsState.count ?? 0 })}
+                      {wsState.alreadyExists
+                        ? t("sync.import_already_exists")
+                        : t("sync.import_done", { count: wsState.count ?? 0 })}
                     </span>
                     {wsState.localPath && (
                       <button

--- a/src/components/sync/CloudImportModal.tsx
+++ b/src/components/sync/CloudImportModal.tsx
@@ -256,7 +256,7 @@ export function CloudImportModal({
                         <summary className="cursor-pointer text-xs text-red-400">
                           {t("sync.import_open_error")}
                         </summary>
-                        <pre className="mt-1 max-h-24 overflow-auto whitespace-pre-wrap break-all rounded bg-red-950/30 p-1.5 text-[10px] text-red-300 select-text">
+                        <pre className="mt-1 max-h-24 overflow-auto rounded bg-red-950/30 p-1.5 text-[10px] break-all whitespace-pre-wrap text-red-300 select-text">
                           {wsState.openError}
                         </pre>
                       </details>

--- a/src/components/sync/CloudImportModal.tsx
+++ b/src/components/sync/CloudImportModal.tsx
@@ -248,12 +248,14 @@ export function CloudImportModal({
                       </button>
                     )}
                     {wsState.openError && (
-                      <span
-                        className="max-w-[180px] truncate text-xs text-red-400"
-                        title={wsState.openError}
-                      >
-                        {t("sync.import_open_error")}
-                      </span>
+                      <details className="mt-1 max-w-[220px]">
+                        <summary className="cursor-pointer text-xs text-red-400">
+                          {t("sync.import_open_error")}
+                        </summary>
+                        <pre className="mt-1 max-h-24 overflow-auto whitespace-pre-wrap break-all rounded bg-red-950/30 p-1.5 text-[10px] text-red-300 select-text">
+                          {wsState.openError}
+                        </pre>
+                      </details>
                     )}
                   </div>
                 )}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -268,6 +268,7 @@
       "import_skip": "Skip",
       "import_downloading": "Downloading...",
       "import_done": "{{count}} file(s) downloaded successfully",
+      "import_already_exists": "Already available locally",
       "import_open": "Open",
       "import_open_error": "Failed to open workspace",
       "import_error": "Download error: {{error}}",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -283,6 +283,7 @@
       "import_skip": "Pular",
       "import_downloading": "Baixando...",
       "import_done": "{{count}} arquivo(s) baixados com sucesso",
+      "import_already_exists": "Já existe localmente",
       "import_open": "Abrir",
       "import_open_error": "Erro ao abrir workspace",
       "import_error": "Erro ao baixar: {{error}}",


### PR DESCRIPTION
This pull request introduces several improvements to error handling, logging, and user experience when importing workspaces, as well as enhancements to build scripts for environment variable management. The main themes are: improved error reporting in storage operations, enhanced workspace import UX to avoid duplicates, and consistent build-time environment variable injection.

**Error handling and logging improvements:**

* Added detailed error context to all file operations in storage modules, such as `atomic_write_bytes`, `acquire_lock`, and related methods, making it easier to trace and debug failures. [[1]](diffhunk://#diff-0ace8c1b270db9fb932c26889ce5f5bb81174aa7ed2c19ec892cfab8a6b49d3dL19-R36) [[2]](diffhunk://#diff-a87d00ff554ac9cb2e0bb1af45c2e06d5e2e45d4d89791e7975a1278b935919eL27-R37) [[3]](diffhunk://#diff-5ec82719608c57eaa4684f9bab16dc0de0dc43e045e3732b792f6c449997c66dL107-R154)
* Introduced `log` dependency in `crates/storage/Cargo.toml` and added debug/error log messages throughout the workspace opening process for better observability. [[1]](diffhunk://#diff-99673d294a9758203eaaa14869cc0d88b287401ea5a009f80eb5483b476b5361R14) [[2]](diffhunk://#diff-5ec82719608c57eaa4684f9bab16dc0de0dc43e045e3732b792f6c449997c66dL107-R154)

**Workspace import user experience:**

* Updated the workspace download logic to check for existing local workspaces by name before downloading, preventing duplicate imports and returning the existing path if found.
* Enhanced the cloud import modal UI to display a specific message ("Already available locally") when a workspace already exists, and improved error message display for failed workspace openings. [[1]](diffhunk://#diff-8dfc59186f02152349aa9024197223e88fc14df7f54ffdd28eae5141f39da390R32) [[2]](diffhunk://#diff-8dfc59186f02152349aa9024197223e88fc14df7f54ffdd28eae5141f39da390R78) [[3]](diffhunk://#diff-8dfc59186f02152349aa9024197223e88fc14df7f54ffdd28eae5141f39da390L238-R242) [[4]](diffhunk://#diff-8dfc59186f02152349aa9024197223e88fc14df7f54ffdd28eae5141f39da390L251-R262) [[5]](diffhunk://#diff-b1791c7a47875ce85f2f1e57ef6c25a9b993660f9bcc840d8f21daac6161b5a0R271) [[6]](diffhunk://#diff-8f3a0cf8394e26b3755643fc71adc9d48caffe815b748da3cc521976bb524f7cR286)

**Build script improvements:**

* Added or updated build scripts in both `src-tauri` and `crates/sync` to automatically load environment variables from `.env.local` at compile time, ensuring credentials and config values are embedded during build without requiring external environment setup. [[1]](diffhunk://#diff-7d1ef5b0b986fee369d8f5fa4361f21fa3075601e5416738ba4f4d1ea5dfb2edR1-R34) [[2]](diffhunk://#diff-04442148c2ff8a62033cf3858fc3e5d1fa4d6e54ae19420013557217c4b3725dR1-R31)