### PR TITLE
Fix GitHub Actions bundle_dmg.sh and update dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,8 @@ jobs:
           DROPBOX_CLIENT_ID: ${{ secrets.DROPBOX_CLIENT_ID }}
           DROPBOX_CLIENT_SECRET: ${{ secrets.DROPBOX_CLIENT_SECRET }}
           ONEDRIVE_CLIENT_ID: ${{ secrets.ONEDRIVE_CLIENT_ID }}
+          # Ad-hoc signing so bundle_dmg.sh can run codesign without a real certificate
+          APPLE_SIGNING_IDENTITY: "-"
         with:
           tagName: ${{ github.event.inputs.tag }}
           releaseName: Open Note ${{ github.event.inputs.tag }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2931,6 +2931,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "libc",
+ "log",
  "opennote-core",
  "rand 0.8.5",
  "serde",


### PR DESCRIPTION
This pull request makes a small change to the GitHub Actions workflow to support ad-hoc code signing for macOS builds. The change adds an `APPLE_SIGNING_IDENTITY` environment variable with a placeholder value, allowing the `bundle_dmg.sh` script to run `codesign` without requiring a real certificate.

* Added `APPLE_SIGNING_IDENTITY: "-"` to the environment variables in `.github/workflows/release.yml` to enable ad-hoc signing for macOS builds.