### PR TITLE
fix(storage): make save_workspace non-fatal on open; add path context…

### DIFF
--- a/crates/storage/src/atomic.rs
+++ b/crates/storage/src/atomic.rs
@@ -73,7 +73,9 @@ pub fn create_dir_all_0755(path: &Path) -> std::io::Result<()> {
             if p.exists() {
                 // Ensure even pre-existing dirs have 0o755 (e.g. the workspace
                 // root created by create_workspace with bare create_dir_all).
-                let _ = fs::set_permissions(&p, fs::Permissions::from_mode(0o755));
+                if let Err(e) = fs::set_permissions(&p, fs::Permissions::from_mode(0o755)) {
+                    log::warn!("chmod 0755 '{}' failed (non-fatal): {e}", p.display());
+                }
                 break;
             }
             to_create.push(p.clone());
@@ -89,11 +91,16 @@ pub fn create_dir_all_0755(path: &Path) -> std::io::Result<()> {
             // Another thread may have created it between our check and here.
             if let Err(e) = fs::create_dir(dir) {
                 if e.kind() != std::io::ErrorKind::AlreadyExists {
-                    return Err(e);
+                    return Err(std::io::Error::new(
+                        e.kind(),
+                        format!("mkdir '{}': {e}", dir.display()),
+                    ));
                 }
             }
             // chmod immediately so the next level can be entered.
-            let _ = fs::set_permissions(dir, fs::Permissions::from_mode(0o755));
+            if let Err(e) = fs::set_permissions(dir, fs::Permissions::from_mode(0o755)) {
+                log::warn!("chmod 0755 '{}' failed (non-fatal): {e}", dir.display());
+            }
         }
 
         Ok(())

--- a/crates/storage/src/engine.rs
+++ b/crates/storage/src/engine.rs
@@ -131,13 +131,16 @@ impl FsStorageEngine {
             "[open_workspace] save_workspace at '{}'",
             root_path.display()
         );
-        Self::save_workspace(&workspace).map_err(|e| {
-            log::error!(
-                "[open_workspace] save_workspace FAILED at '{}': {e}",
+        // Non-fatal: updated_at is cosmetic metadata. If the workspace directory has
+        // restrictive permissions (e.g. downloaded under a bad umask), the repair above
+        // may not have fully fixed it yet.  We log the problem but still open the
+        // workspace so the user is not locked out.
+        if let Err(e) = Self::save_workspace(&workspace) {
+            log::warn!(
+                "[open_workspace] save_workspace FAILED at '{}' (non-fatal, workspace will still open): {e}",
                 root_path.join(WORKSPACE_FILE).display()
             );
-            e
-        })?;
+        }
 
         log::debug!(
             "[open_workspace] cleanup_expired_trash at '{}'",


### PR DESCRIPTION
… to mkdir errors

The save_workspace call in open_workspace only updates the cosmetic updated_at timestamp. Treating it as a fatal error locked users out of workspaces downloaded under a restrictive umask (EACCES on Ubuntu).

- open_workspace: downgrade save_workspace failure to log::warn so the workspace still opens even if the metadata file can't be written yet
- create_dir_all_0755: wrap mkdir errors with the directory path so logs show exactly which path caused EACCES
- create_dir_all_0755: log (non-fatal) instead of silently ignoring chmod failures, making permission repair issues visible in logs